### PR TITLE
Feat: Parameterize JHOVE folder mappings via dynamic properties (TT-2324)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 target/
+.flattened-pom.xml
+docs/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Denne flowen skal vi bruke for lokal utvikling, og du kan bruke volume mountene 
 | `./nifi-tekst-bundle-processors/src/test/resources` | `/data/test-resources`                  | Testfiler for utvikling og testing (read-only)    |
 | `./nifi-docker/output`                              | `/data/output`                          | Mappe for output fra NiFi-flows                   |
 
+Testfiler fra `nifi-tekst-bundle-processors/src/test/resources` er tilgjengelig i containeren under `/data/test-resources` og kan brukes direkte som input når du tester prosessorer manuelt i NiFi.
+
+For å nullstille testressurser til opprinnelig tilstand (fjerner også genererte filer som er gitignorert):
+
+```bash
+git clean -fdx nifi-tekst-bundle-processors/src/test/resources/
+```
+
 ### Rebuild etter endringer
 
 Etter endringer i prosessor-koden:
@@ -69,6 +77,12 @@ docker compose restart nifi
 Utrulling skjer via opplastning til Artifactory, og deretter nedlastning fra NiFi i stage/prod miljøene.
 
 Bruk NiFi flowen "Update NAR Packages"
+
+## Versjonering
+
+Bundle-versjonen (den som vises i NiFi når du legger til en prosessor) styres fra én plass: `<revision>` i rot-`pom.xml`. Undermodulene arver denne via `${revision}`.
+
+For å bumpe versjonen, endre bare `<revision>` i `pom.xml`.
 
 ## Vedlikehold
 

--- a/nifi-tekst-bundle-nar/pom.xml
+++ b/nifi-tekst-bundle-nar/pom.xml
@@ -21,11 +21,11 @@
     <parent>
         <groupId>no.nb.nifi</groupId>
         <artifactId>nifi-tekst-bundle</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>nifi-tekst-bundle-nar</artifactId>
-    <version>2.0.0</version>
+    <version>${revision}</version>
     <packaging>nar</packaging>
     <properties>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/nifi-tekst-bundle-processors/pom.xml
+++ b/nifi-tekst-bundle-processors/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>no.nb.nifi</groupId>
         <artifactId>nifi-tekst-bundle</artifactId>
-        <version>2.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>nifi-tekst-bundle-processors</artifactId>

--- a/nifi-tekst-bundle-processors/src/main/kotlin/no/nb/nifi/tekst/processors/Jhove.kt
+++ b/nifi-tekst-bundle-processors/src/main/kotlin/no/nb/nifi/tekst/processors/Jhove.kt
@@ -81,9 +81,9 @@ class Jhove : AbstractProcessor() {
         private val FOLDER_MAPPINGS = mapOf(
 			"metadata/descriptive" to "metadata/other/jhove",
             "representations/primary/data" to "representations/primary/metadata/technical/jhove",
-            "representations/primary/metadata/other/ocr" to "representations/primary/metadata/other/jhove-ocr",
-            "representations/access/data" to "representations/access/metadata/technical/jhove",
-			"representations/access/metadata/other/ocr" to "representations/access/metadata/other/jhove-ocr"
+            "representations/primary/metadata/other/ocr-for-transformed" to "representations/primary/metadata/other/jhove-ocr-for-transformed",
+			"representations/primary/metadata/other/transformation" to "representations/primary/metadata/other/jhove-transformation",
+			"representations/access/data" to "representations/access/metadata/technical/jhove",
         )
 
         // File type to JHOVE module mapping

--- a/nifi-tekst-bundle-processors/src/main/kotlin/no/nb/nifi/tekst/processors/Jhove.kt
+++ b/nifi-tekst-bundle-processors/src/main/kotlin/no/nb/nifi/tekst/processors/Jhove.kt
@@ -24,7 +24,12 @@ import javax.xml.xpath.XPathFactory
 @Tags("NB", "Validation", "JHOVE")
 @CapabilityDescription(
     "Validates files in subfolders of an object folder with JHOVE and writes XML output to corresponding target folders. " +
-    "By default validates five standard subfolder pairs (metadata/descriptive, representations/primary/data, etc.). " +
+    "Default folder mappings (source → target): " +
+    "metadata/descriptive → metadata/other/jhove; " +
+    "representations/primary/data → representations/primary/metadata/technical/jhove; " +
+    "representations/primary/metadata/other/ocr-for-transformed → representations/primary/metadata/other/jhove-ocr-for-transformed; " +
+    "representations/primary/metadata/other/transformation → representations/primary/metadata/other/jhove-transformation; " +
+    "representations/access/data → representations/access/metadata/technical/jhove. " +
     "To override, add dynamic properties where the property name is the source subfolder path and the value is the target subfolder path — " +
     "when any dynamic property is present, only dynamic mappings are used (defaults are not merged). " +
     "Note: <mixVersion>1.0</mixVersion> is set in jhoveconf.xml to ensure MIX10-compatible output for CreateMetsBrowsing."

--- a/nifi-tekst-bundle-processors/src/main/kotlin/no/nb/nifi/tekst/processors/Jhove.kt
+++ b/nifi-tekst-bundle-processors/src/main/kotlin/no/nb/nifi/tekst/processors/Jhove.kt
@@ -23,12 +23,19 @@ import javax.xml.xpath.XPathFactory
 
 @Tags("NB", "Validation", "JHOVE")
 @CapabilityDescription(
-    ("Validates required files in subfolders of an object folder with JHOVE and writes the JHOVE XML output to the corresponding target folders. " +
-            "The processor validates files in defined subfolders, checking all generated XML files to return valid/well-formed statuses. " +
-            "Note that to force XML output compliant with MIX10, and hence compatible with CreateMetsBrowsing, " +
-            "we've added <mixVersion>1.0</mixVersion> to jhoveconf.xml")
+    "Validates files in subfolders of an object folder with JHOVE and writes XML output to corresponding target folders. " +
+    "By default validates five standard subfolder pairs (metadata/descriptive, representations/primary/data, etc.). " +
+    "To override, add dynamic properties where the property name is the source subfolder path and the value is the target subfolder path — " +
+    "when any dynamic property is present, only dynamic mappings are used (defaults are not merged). " +
+    "Note: <mixVersion>1.0</mixVersion> is set in jhoveconf.xml to ensure MIX10-compatible output for CreateMetsBrowsing."
 )
 @SupportsBatching
+@DynamicProperty(
+    name = "Source subfolder path",
+    value = "Target subfolder path",
+    description = "Maps a source subfolder to a custom JHOVE output target subfolder. When any dynamic property is present, only dynamic mappings are used (defaults are not merged).",
+    expressionLanguageScope = ExpressionLanguageScope.NONE
+)
 class Jhove : AbstractProcessor() {
     private var descriptors: MutableList<PropertyDescriptor> = mutableListOf()
     private var relationships: MutableSet<Relationship> = mutableSetOf()
@@ -210,6 +217,25 @@ class Jhove : AbstractProcessor() {
 
     override fun getSupportedPropertyDescriptors(): List<PropertyDescriptor> {
         return descriptors
+    }
+
+    override fun getSupportedDynamicPropertyDescriptor(propertyDescriptorName: String): PropertyDescriptor =
+        PropertyDescriptor.Builder()
+            .name(propertyDescriptorName)
+            .displayName(propertyDescriptorName)
+            .description("Target subfolder for JHOVE output from source subfolder '$propertyDescriptorName'")
+            .required(false)
+            .addValidator(StandardValidators.NON_BLANK_VALIDATOR)
+            .expressionLanguageSupported(ExpressionLanguageScope.NONE)
+            .dynamic(true)
+            .build()
+
+    private fun effectiveMappings(context: ProcessContext): Map<String, String> {
+        val dynamic = context.properties.entries
+            .filter { it.key.isDynamic }
+            .associate { it.key.name to (it.value ?: "") }
+            .filterValues { it.isNotBlank() }
+        return if (dynamic.isEmpty()) FOLDER_MAPPINGS else dynamic
     }
 
     /**
@@ -440,7 +466,7 @@ class Jhove : AbstractProcessor() {
             val allValidationResults = mutableListOf<FileValidationStatus>()
 
             // Process each configured folder mapping
-            for ((sourceSubfolder, targetSubfolder) in FOLDER_MAPPINGS) {
+            for ((sourceSubfolder, targetSubfolder) in effectiveMappings(context)) {
                 val sourcePath = objectFolder.resolve(sourceSubfolder)
                 val targetPath = objectFolder.resolve(targetSubfolder)
 

--- a/nifi-tekst-bundle-processors/src/test/kotlin/no/nb/nifi/tekst/processors/JhoveTest.kt
+++ b/nifi-tekst-bundle-processors/src/test/kotlin/no/nb/nifi/tekst/processors/JhoveTest.kt
@@ -48,21 +48,14 @@ class JhoveTest {
 
         val primaryOutputDir = objectFolder.resolve("representations/primary/metadata/technical/jhove").toFile()
         val accessOutputDir = objectFolder.resolve("representations/access/metadata/technical/jhove").toFile()
-        val ocrOutputDir = objectFolder.resolve("representations/access/metadata/other/jhove-ocr").toFile()
         val descriptiveOutputDir = objectFolder.resolve("metadata/other/jhove").toFile()
 
         assertTrue(primaryOutputDir.exists(), "Primary JHOVE output dir should exist")
         assertTrue(accessOutputDir.exists(), "Access JHOVE output dir should exist")
-        assertTrue(ocrOutputDir.exists(), "OCR JHOVE output dir should exist")
         assertTrue(descriptiveOutputDir.exists(), "Descriptive JHOVE output dir should exist")
 
         assertEquals(4, primaryOutputDir.listFiles { file -> file.name.endsWith(".xml") }?.size)
         assertEquals(4, accessOutputDir.listFiles { file -> file.name.endsWith(".xml") }?.size)
-        assertEquals(4, ocrOutputDir.listFiles { file ->
-                file.name.endsWith(".xml")
-                        && !file.name.endsWith("mets.xml.xml", ignoreCase = true)
-            }?.size
-        )
         assertEquals(1, descriptiveOutputDir.listFiles { file -> file.name.endsWith(".xml") }?.size)
     }
 
@@ -78,7 +71,7 @@ class JhoveTest {
             )
             copyDir(
                 fixtureRoot.resolve("representations/access/metadata/other/ocr"),
-                noAccessFolder.resolve("representations/primary/metadata/other/ocr")
+                noAccessFolder.resolve("representations/primary/metadata/other/ocr-for-transformed")
             )
 
             val runner = TestRunners.newTestRunner(Jhove::class.java)
@@ -90,20 +83,20 @@ class JhoveTest {
             assertProcessed(runner)
 
             val primaryOcrJhoveDir =
-                noAccessFolder.resolve("representations/primary/metadata/other/jhove-ocr").toFile()
-            assertTrue(primaryOcrJhoveDir.exists(), "Primary OCR JHOVE output dir should exist")
+                noAccessFolder.resolve("representations/primary/metadata/other/jhove-ocr-for-transformed").toFile()
+            assertTrue(primaryOcrJhoveDir.exists(), "Primary OCR-for-transformed JHOVE output dir should exist")
             assertEquals(
                 4,
                 primaryOcrJhoveDir.listFiles { file ->
                     file.name.endsWith(".xml")
                             && !file.name.endsWith("mets.xml.xml", ignoreCase = true)
                 }?.size,
-                "Primary OCR JHOVE output should be generated for every OCR file"
+                "Primary OCR-for-transformed JHOVE output should be generated for every OCR file"
             )
 
             // No access representation present, so no access JHOVE output should be produced.
             assertFalse(
-                noAccessFolder.resolve("representations/access/metadata/other/jhove-ocr").toFile().exists(),
+                noAccessFolder.resolve("representations/access/metadata/other/jhove-ocr-for-transformed").toFile().exists(),
                 "Access OCR JHOVE output dir should not be created when no access representation exists"
             )
         } finally {

--- a/nifi-tekst-bundle-processors/src/test/kotlin/no/nb/nifi/tekst/processors/JhoveTest.kt
+++ b/nifi-tekst-bundle-processors/src/test/kotlin/no/nb/nifi/tekst/processors/JhoveTest.kt
@@ -34,6 +34,7 @@ class JhoveTest {
         TestObjectFolderHelper.deleteTempObjectFolder(objectFolder)
     }
 
+    // Covers the fallback path: no dynamic properties configured → FOLDER_MAPPINGS defaults are used
     @Test
     fun testValidProcessingCreatesJhoveOutputs() {
         val runner = TestRunners.newTestRunner(Jhove::class.java)
@@ -108,6 +109,31 @@ class JhoveTest {
         } finally {
             noAccessFolder.toFile().deleteRecursively()
         }
+    }
+
+    @Test
+    fun testDynamicMappingsReplaceDefaults() {
+        val runner = TestRunners.newTestRunner(Jhove::class.java)
+        runner.setProperty(Jhove.OBJECT_FOLDER, objectFolder.toString())
+
+        // Dynamic property: name = source subfolder, value = custom target subfolder
+        runner.setProperty("representations/primary/data", "custom/jhove/test-output")
+
+        runner.enqueue("test")
+        runner.run()
+
+        assertProcessed(runner)
+
+        // Custom target must have JHOVE output
+        val customOutputDir = objectFolder.resolve("custom/jhove/test-output").toFile()
+        assertTrue(customOutputDir.exists(), "Custom dynamic target dir should exist")
+        val xmlFiles = customOutputDir.listFiles { f -> f.name.endsWith(".xml") }
+        assertNotNull(xmlFiles, "Custom target dir should contain files")
+        assertTrue(xmlFiles!!.isNotEmpty(), "Custom target dir should contain at least one JHOVE XML file")
+
+        // Default-only folder must NOT be created (replace, not merge)
+        val defaultDescriptiveDir = objectFolder.resolve("metadata/other/jhove").toFile()
+        assertFalse(defaultDescriptiveDir.exists(), "Default mapping folder should not be created when dynamic props are set")
     }
 
     private fun copyDir(source: Path, target: Path) {

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     </parent>
 
     <properties>
+        <revision>2.1.0</revision>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -31,7 +32,7 @@
 
     <groupId>no.nb.nifi</groupId>
     <artifactId>nifi-tekst-bundle</artifactId>
-    <version>2.0.0</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -99,6 +100,31 @@
                             </rules>
                             <fail>true</fail>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary

- Replaces hardcoded `FOLDER_MAPPINGS` in the `Jhove` processor with NiFi dynamic properties
- When no dynamic properties are configured, hardcoded mappings are used as fallback
- When any dynamic property is present, only dynamic mappings run (replace, not merge)

## How it works

Add dynamic properties in the NiFi UI where the **property name** is the source subfolder (relative to the object folder) and the **value** is the target subfolder for JHOVE XML output.